### PR TITLE
declared special member functions private to prevent them from being used or being created by the compiler

### DIFF
--- a/src/include/Discretization.hpp
+++ b/src/include/Discretization.hpp
@@ -46,6 +46,13 @@ class Discretization {
   int get_num_dofs() { return _disc.real_na; }
 
  private:
+  // we declare functionality which has not been implemented (yet)
+  // to be private
+  Discretization(const Discretization<Derived>& H);
+  Discretization(Discretization<Derived>&& H);
+  Discretization& operator=(const Discretization<Derived>& H);
+  Discretization& operator=(Discretization<Derived>&& H);
+  // member variables
   discretization _disc;
   Geometry _geo;
   Mesh _msh;

--- a/src/include/HierarchicalMatrix.hpp
+++ b/src/include/HierarchicalMatrix.hpp
@@ -116,6 +116,13 @@ class HierarchicalMatrix : public EigenBase<HierarchicalMatrix<Derived> > {
   const Derived& get_matVecHandle() const { return _matVecHandle; }
 
  private:
+  // we declare functionality which has not been implemented (yet)
+  // to be private
+  HierarchicalMatrix(const HierarchicalMatrix<Derived>& H);
+  HierarchicalMatrix(HierarchicalMatrix<Derived>&& H);
+  HierarchicalMatrix& operator=(const HierarchicalMatrix<Derived>& H);
+  HierarchicalMatrix& operator=(HierarchicalMatrix<Derived>&& H);
+  // member variables
   int _nct;
   Bembel::ct_root* _H;
   Bembel::hmatrixsettings _hmatset; /* settings for H-matrix discretization */

--- a/src/include/Mesh.hpp
+++ b/src/include/Mesh.hpp
@@ -25,6 +25,12 @@ class Mesh {
   meshdata &get_mesh() { return _mesh; }
 
  private:
+  // we declare functionality which has not been implemented (yet)
+  // to be private
+  Mesh(const Mesh& other);
+  Mesh(Mesh&& other);
+  Mesh& operator=(const Mesh& other);
+  Mesh& operator=(Mesh&& other);
   meshdata _mesh;
 };
 }  // namespace Bembel


### PR DESCRIPTION
declared special members in HierarchicalMatrix and Discretization private to prevent them from being used