### PR TITLE
map2surface auto variable issue

### DIFF
--- a/Bembel/src/AnsatzSpace/SuperSpace.hpp
+++ b/Bembel/src/AnsatzSpace/SuperSpace.hpp
@@ -116,9 +116,8 @@ struct SuperSpace {
   //////////////////////////////////////////////////////////////////////////////
   void map2surface(const ElementTreeNode& e, const Eigen::Vector2d& xi,
                    double w, SurfacePoint* surf_pt) const {
-    auto Chi = mesh_->get_geometry()[e.patch_];
     Eigen::Vector2d st = e.llc_ + e.get_h() * xi;
-    Chi.updateSurfacePoint(surf_pt, st, w, xi);
+    mesh_->get_geometry()[e.patch_].updateSurfacePoint(surf_pt, st, w, xi);
     return;
   }
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
removed a stupid auto variable which caused a constructor evocation every time a quadrature point is evaluated...