### PR TITLE
Fixes to make Bembel compatible to VisualStudio

### DIFF
--- a/Bembel/Quadrature
+++ b/Bembel/Quadrature
@@ -18,6 +18,7 @@
 #include <Eigen/Eigenvalues>
 
 // Module headers
+#include "src/util/Macros.hpp"
 #include "src/Quadrature/Quadrature.hpp"
 #include "src/Quadrature/Cubature.hpp"
 #include "src/Quadrature/GaussLegendreRule.hpp"

--- a/Bembel/src/AnsatzSpace/Glue.hpp
+++ b/Bembel/src/AnsatzSpace/Glue.hpp
@@ -132,7 +132,7 @@ class Glue {
       const int pre_index = i + skip;
       trips.push_back(Eigen::Triplet<double>(pre_index, post_index, 1));
       // The dof cannot be declared slave and master at the same time
-      assert(not(dof_is_master[pre_index] && dof_is_slave[pre_index]));
+      assert(!(dof_is_master[pre_index] && dof_is_slave[pre_index]));
       if (dof_is_master[pre_index]) {
         // The dofs in dof_id don't know they might be moved forward. So the
         // smallest dof of those to be identified should coincide with the
@@ -219,13 +219,13 @@ inline bool edgeIsForwardParametrized(int edgeCase) {
   return edgeCase == 0 || edgeCase == 1;
 }
 inline bool edgeIsBackwardsParametrized(int edgeCase) {
-  return not(edgeIsForwardParametrized(edgeCase));
+  return !(edgeIsForwardParametrized(edgeCase));
 }
 inline bool normalComponentIsInwardDirected(int edgeCase) {
   return edgeCase == 0 || edgeCase == 3;
 }
 inline bool normalComponentIsOutwardDirected(int edgeCase) {
-  return not(normalComponentIsInwardDirected(edgeCase));
+  return !(normalComponentIsInwardDirected(edgeCase));
 }
 
 inline bool reverseParametrized(const std::array<int, 4> &edge) {
@@ -323,7 +323,7 @@ struct glue_identificationmaker_<Derived, DifferentialForm::Continuous> {
               out[already_stored_in[small_dof]].dofs.push_back(large_dof);
               already_stored_in[large_dof] = already_stored_in[small_dof];
             } else {
-              if (not(already_stored_in[small_dof] ==
+              if (!(already_stored_in[small_dof] ==
                       already_stored_in[large_dof])) {
                 // This case is tricky. Assume that we have to identify four
                 // DOFs with each other, but they have already been assigned in
@@ -355,7 +355,7 @@ struct glue_identificationmaker_<Derived, DifferentialForm::Continuous> {
               out[already_stored_in[large_dof]].dofs.push_back(small_dof);
               already_stored_in[small_dof] = already_stored_in[large_dof];
             } else {
-              if (not(already_stored_in[small_dof] ==
+              if (!(already_stored_in[small_dof] ==
                       already_stored_in[large_dof])) {
                 // This case is tricky. Assume that we have to identify four
                 // DOFs with each other, but they have already been assigned in

--- a/Bembel/src/AnsatzSpace/Projector.hpp
+++ b/Bembel/src/AnsatzSpace/Projector.hpp
@@ -146,8 +146,8 @@ inline _proj_info makeLocalProjectionTriplets(
   // Here, we suddenly use the degree for basisevaluation, i.e.,
   // maximal_polynomial_degree-1. This is confusing, but correct and tested.
   {
-    double vals_y[maximal_polynomial_degree];
-    double vals_x[maximal_polynomial_degree];
+    double vals_y[Constants::MaxP + 1];
+    double vals_x[Constants::MaxP + 1];
     for (int iy = 0; iy < maximal_polynomial_degree; ++iy) {
       Bembel::Basis::ShapeFunctionHandler::evalBasis(
           maximal_polynomial_degree - 1, vals_y, mask[iy]);
@@ -188,13 +188,13 @@ inline _proj_info makeLocalProjectionTriplets(
     nonzero_dofs_x.reserve(pp1x);
     nonzero_dofs_y.reserve(pp1y);
     for (int dof_y = 0; dof_y < c_space_dim_y; ++dof_y) {
-      if ((c_space_knot_y[dof_y] <= mid_y) and
+      if ((c_space_knot_y[dof_y] <= mid_y) &&
           (c_space_knot_y[dof_y + pp1y] >= mid_y)) {
         nonzero_dofs_y.push_back(dof_y);
       }
     }
     for (int dof_x = 0; dof_x < c_space_dim_x; ++dof_x) {
-      if ((c_space_knot_x[dof_x] <= mid_x) and
+      if ((c_space_knot_x[dof_x] <= mid_x) &&
           (c_space_knot_x[dof_x + pp1x] >= mid_x)) {
         nonzero_dofs_x.push_back(dof_x);
       }
@@ -212,8 +212,8 @@ inline _proj_info makeLocalProjectionTriplets(
         for (int i = 0; i < masksize; ++i) {
           local_mask_x[i] = pos_x + (1.0 / n) * mask[i];
           local_mask_y[i] = pos_y + (1.0 / n) * mask[i];
-          assert(local_mask_x[i] < 1 and local_mask_x[i] > 0);
-          assert(local_mask_y[i] < 1 and local_mask_y[i] > 0);
+          assert(local_mask_x[i] < 1 && local_mask_x[i] > 0);
+          assert(local_mask_y[i] < 1 && local_mask_y[i] > 0);
         }
 
         // build unit vectors

--- a/Bembel/src/ClusterTree/ElementTree.hpp
+++ b/Bembel/src/ClusterTree/ElementTree.hpp
@@ -417,7 +417,7 @@ class ElementTree {
       if(cur_neighbour != -1){
         ElementTreeNode &ref_cur_neighbour = mem_->adjcent(cur_el, i);
         // is the neighbour already refined?
-        if (cur_neighbour != -1 && ref_cur_neighbour.sons_.size()) {
+        if (ref_cur_neighbour.sons_.size()) {
           // this is the midpoint of the shared edge
           ptIds[i] = mem_->son(ref_cur_neighbour, refNeighbours[i])
                          .vertices_[(refNeighbours[i] + 1) % 4];

--- a/Bembel/src/ClusterTree/ElementTree.hpp
+++ b/Bembel/src/ClusterTree/ElementTree.hpp
@@ -414,22 +414,24 @@ class ElementTree {
     //  determine new points
     for (auto i = 0; i < 4; ++i) {
       auto cur_neighbour = cur_el.adjcents_[i];
-      ElementTreeNode &ref_cur_neighbour = mem_->adjcent(cur_el, i);
-      // is the neighbour already refined?
-      if (cur_neighbour != -1 && ref_cur_neighbour.sons_.size()) {
-        // this is the midpoint of the shared edge
-        ptIds[i] = mem_->son(ref_cur_neighbour, refNeighbours[i])
-                       .vertices_[(refNeighbours[i] + 1) % 4];
-        // these are the two elements adjacent to the edge
-        elements.push_back(
-            std::addressof(mem_->son(ref_cur_neighbour, refNeighbours[i])));
-        elements.push_back(std::addressof(
-            mem_->son(ref_cur_neighbour, (refNeighbours[i] + 1) % 4)));
-      }
-      // otherwise add the point id to the tree
-      else {
-        ptIds[i] = number_of_points_;
-        ++number_of_points_;
+      if(cur_neighbour != -1){
+        ElementTreeNode &ref_cur_neighbour = mem_->adjcent(cur_el, i);
+        // is the neighbour already refined?
+        if (cur_neighbour != -1 && ref_cur_neighbour.sons_.size()) {
+          // this is the midpoint of the shared edge
+          ptIds[i] = mem_->son(ref_cur_neighbour, refNeighbours[i])
+                         .vertices_[(refNeighbours[i] + 1) % 4];
+          // these are the two elements adjacent to the edge
+          elements.push_back(
+              std::addressof(mem_->son(ref_cur_neighbour, refNeighbours[i])));
+          elements.push_back(std::addressof(
+              mem_->son(ref_cur_neighbour, (refNeighbours[i] + 1) % 4)));
+        }
+        // otherwise add the point id to the tree
+        else {
+          ptIds[i] = number_of_points_;
+          ++number_of_points_;
+        }
       }
     }
     // add midpoint of the current element, which is always a new point

--- a/Bembel/src/IO/Logger.hpp
+++ b/Bembel/src/IO/Logger.hpp
@@ -60,7 +60,7 @@ class Logger {
   }
   template <typename T, typename... Args>
   void file(T t, Args... arg) {
-    if (not(_file.is_open())) {
+    if (!(_file.is_open())) {
       _file.open(name_, std::fstream::out | std::fstream::trunc);
     }
     _file << std::setprecision(N - 4) << std::setw(N + _sep.size()) << std::left
@@ -69,7 +69,7 @@ class Logger {
   }
   template <typename T>
   void file(T t) {
-    if (not(_file.is_open())) {
+    if (!(_file.is_open())) {
       _file.open(name_, std::fstream::out | std::fstream::trunc);
     }
     std::setprecision(N);

--- a/Bembel/src/Spline/Localize.hpp
+++ b/Bembel/src/Spline/Localize.hpp
@@ -66,7 +66,7 @@ inline Eigen::Matrix<double, -1, -1> GetInterpolationMatrix(
   Eigen::Matrix<double, -1, -1> interpolationMatrix(polynomial_degree + 1,
                                                     polynomial_degree + 1);
 
-  double val[polynomial_degree + 1];
+  double val[Constants::MaxP + 1];
   for (int j = 0; j < polynomial_degree + 1; j++) {
     Bembel::Basis::ShapeFunctionHandler::evalBasis(polynomial_degree, val,
                                                    mask[j]);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,28 @@ provided WITHOUT ANY WARRANTY, see <http://www.bembel.eu> for further
 information.
 ")
 
+
+#   Instructions for VisualStudio users (tested with VS 2019 Community)
+#
+#   Assuming you do not have some preixisting setup, you can compile 
+#   tests and examples as follows: Uncomment the options
+#
+#   add_compile_options(-bigobj)
+#   include_directories(eigen3)
+#
+#   in this file, and comment out the line  
+
 find_package (Eigen3 3.3 REQUIRED NO_MODULE)
+
+#   below. Then place the eigen3 directory obtained from downloading 
+#   Eigen in Bembels root directory, where this CMake file sits. 
+#   Afterwards, comment or remove the 
+#
+#   target_link_libraries(example_Quadrature.out Eigen3::Eigen)
+#
+#   lines in the CMake-Files of "\examples" and "\tests".
+
+
 set (BEMBEL_PATH "${PROJECT_SOURCE_DIR}")
 
 include(CheckCXXCompilerFlag)

--- a/examples/example_Quadrature.cpp
+++ b/examples/example_Quadrature.cpp
@@ -68,15 +68,15 @@ int main() {
 
     // tensor product quadrature
     {
-      double exact_integral = (std::cos(M_PI) - std::cos(0)) / M_PI;
+      double exact_integral = (std::cos(BEMBEL_PI) - std::cos(0)) / BEMBEL_PI;
       exact_integral *= exact_integral;
 
       Bembel::GaussSquare<max_tp_order> GS;
       for (auto j = 0; j < max_tp_order; ++j) {
         double quadrature_val = 0;
         for (auto i = 0; i < GS[j].xi_.cols(); ++i)
-          quadrature_val += GS[j].w_(i) * std::sin(M_PI * GS[j].xi_(0, i)) *
-                            std::sin(M_PI * GS[j].xi_(1, i));
+          quadrature_val += GS[j].w_(i) * std::sin(BEMBEL_PI * GS[j].xi_(0, i)) *
+                            std::sin(BEMBEL_PI * GS[j].xi_(1, i));
         std::cout << "TP quadrature degree " << j + 1 << " error: "
                   << std::abs(quadrature_val - exact_integral) /
                          std::abs(exact_integral)

--- a/tests/Test.hpp
+++ b/tests/Test.hpp
@@ -18,7 +18,7 @@
 
 #define BEMBEL_TEST_IF(in_bool)                                                \
   {                                                                            \
-    if (not(in_bool)) {                                                        \
+    if (!(in_bool)) {                                                        \
       assert(in_bool);                                                         \
       std::cout << "A test failed. Please recompile without -DNDEBUG to see "; \
       std::cout << "the corresponding assert.";                                \


### PR DESCRIPTION
This includes replacing "and" by "&&", "not" by "!" and
"M_PI" by "BEMBEL_PI", as well as one minor fix in ElementTree.
Therein, a reference to possibly non-allocated memory was created,
and a check for allocation was performed afterwards. Although
this was technically correct, since the case of non-allocation was
treated specifically, this would trigger asserts in Microsofts
implementation of std::vector when compiled with debug flags.
Now, we check for allocation before.