### PR TITLE
Split Github Actions Workflows for Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
-name: CMake
+name: Build
 
 on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
 
 env:
   # Customize the CMake build type here (Release, Debug, etc.)
@@ -46,11 +47,12 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
-
-    - name: Test
-      working-directory: ${{github.workspace}}/build
+      run: cmake --build . --config $BUILD_TYPE --target ${{ inputs.target }}
+    - name: Debug
       shell: bash
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: pwd && ls -la
+    - name: Upload Executables
+      uses: actions/upload-artifact@v3
+      with:
+        name: build
+        path: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE --target ${{ inputs.target }}
+      run: cmake --build . --config $BUILD_TYPE --target ${{ inputs.target }} -j 2
     - name: Debug
       shell: bash
       run: pwd && ls -la

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -1,0 +1,35 @@
+name: End-2-End Tests
+
+on:
+  pull_request:
+    branches: [ "**" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      target: examples
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Executables
+      uses: actions/download-artifact@v3
+      with:
+        name: build
+        path: ${{github.workspace}}/build
+    - name: Change Permission
+      shell: bash
+      # Downloaded artifacts loose permissions.
+      # See https://github.com/actions/download-artifact/blob/main/README.md
+      run: chmod +wx build/tests/*.out build/examples/*.out
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C $BUILD_TYPE -E2E --output-on-failure

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -26,7 +26,7 @@ jobs:
       shell: bash
       # Downloaded artifacts loose permissions.
       # See https://github.com/actions/download-artifact/blob/main/README.md
-      run: chmod +wx build/tests/*.out build/examples/*.out
+      run: chmod +wx build/tests/* build/examples/*
     - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,37 @@
+name: Unittests
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      target: unittests
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Executables
+      uses: actions/download-artifact@v3
+      with:
+        name: build
+        path: ${{github.workspace}}/build
+    - name: Change Permission
+      shell: bash
+      # Downloaded artifacts loose permissions.
+      # See https://github.com/actions/download-artifact/blob/main/README.md
+      run: chmod +wx build/tests/* build/examples/*
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C $BUILD_TYPE -L unit --output-on-failure

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,12 +20,15 @@ set(CIFILES
     )
 
 foreach(file IN LISTS CIFILES)
-  add_executable(${file}.out ${file})
-  target_link_libraries(${file}.out Eigen3::Eigen)
-  add_test(${file}Example ${file}.out)
+  add_executable(${file} ${file})
+  target_link_libraries(${file} Eigen3::Eigen)
+  add_test(${file}Example ${file})
 endforeach()
 
 enable_testing()
+
+add_custom_target(examples)
+add_dependencies(examples ${CIFILES})
 
 ###############################################################################
 # examples not being run from CI

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,37 +1,22 @@
-add_executable(test_Spline.out test_Spline)
-target_link_libraries(test_Spline.out Eigen3::Eigen)
-add_test(Spline test_Spline.out)
+set(UNITTESTS
+		test_GeometryImportAndEval
+		test_SurfacePointUpdate
+		test_Projector
+		test_Glue
+		test_FMMTransferMatrices
+		test_FMMForwardTransformation
+		test_FMMBackwardTransformation
+		test_DuffyTrick
+		)
 
-add_executable(test_GeometryImportAndEval.out test_GeometryImportAndEval)
-target_link_libraries(test_GeometryImportAndEval.out Eigen3::Eigen)
-add_test(GeometryImportAndEval test_GeometryImportAndEval.out)
-
-add_executable(test_SurfacePointUpdate.out test_SurfacePointUpdate)
-target_link_libraries(test_SurfacePointUpdate.out Eigen3::Eigen)
-add_test(SurfacePointUpdate test_SurfacePointUpdate.out)
-
-add_executable(test_Projector.out test_Projector)
-target_link_libraries(test_Projector.out Eigen3::Eigen)
-add_test(Projector test_Projector.out)
-
-add_executable(test_Glue.out test_Glue)
-target_link_libraries(test_Glue.out Eigen3::Eigen)
-add_test(Glue test_Glue.out)
-
-add_executable(test_FMMTransferMatrices.out test_FMMTransferMatrices)
-target_link_libraries(test_FMMTransferMatrices.out Eigen3::Eigen)
-add_test(FMMTransferMatrices test_FMMTransferMatrices.out)
-
-add_executable(test_FMMForwardTransformation.out test_FMMForwardTransformation)
-target_link_libraries(test_FMMForwardTransformation.out Eigen3::Eigen)
-add_test(FMMForwardTransformation test_FMMForwardTransformation.out)
-
-add_executable(test_FMMBackwardTransformation.out test_FMMBackwardTransformation)
-target_link_libraries(test_FMMBackwardTransformation.out Eigen3::Eigen)
-add_test(FMMBackwardTransformation test_FMMBackwardTransformation.out)
-
-add_executable(test_DuffyTrick.out test_DuffyTrick)
-target_link_libraries(test_DuffyTrick.out Eigen3::Eigen)
-add_test(DuffyTrick test_DuffyTrick.out)
+foreach(file IN LISTS UNITTESTS)
+  add_executable(${file} ${file}.cpp)
+  target_link_libraries(${file} Eigen3::Eigen)
+  add_test(${file}Unittest ${file})
+  set_tests_properties(${file}Unittest PROPERTIES LABELS "unit")
+endforeach()
 
 enable_testing()
+
+add_custom_target(unittests)
+add_dependencies(unittests ${UNITTESTS})


### PR DESCRIPTION
This contribution splits the Github Actions workflow to run only the unittests on each push. Once a pull request is opened, the Time and Resources elaborate ent-2-end/integration tests are run additionally