### PR TITLE
GitHub actions fix

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and Test
 
 on:
   workflow_call:
@@ -12,7 +12,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
+  build-n-test:
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -28,30 +28,17 @@ jobs:
     - name: Install Eigen3
       run: sudo apt-get install --yes libeigen3-dev
 
-    - name: Debug
-      run: cmake -version
-    - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      run: cmake -E make_directory ${{github.workspace}}/build
-
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
-      working-directory: ${{github.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source 
-      # and build directories, but this is only available with CMake 3.13 and higher.  
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -B build
 
     - name: Build
+      shell: bash
+      run: cmake --build build --config $BUILD_TYPE --target ${{ inputs.target }} -j 2
+
+    - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE --target ${{ inputs.target }} -j 2
-    - name: Upload Executables
-      uses: actions/upload-artifact@v3
-      with:
-        name: build
-        path: build
+      run: ctest -C $BUILD_TYPE -L ${{ inputs.target }} --output-on-failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
     - name: Install Eigen3
       run: sudo apt-get install --yes libeigen3-dev
 
+    - name: Debug
+      run: cmake -version
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,6 +1,10 @@
 name: Check for Google C++ Style Guide
 
-on: [push]
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
 
 jobs:
   code-style:

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -4,32 +4,8 @@ on:
   pull_request:
     branches: [ "**" ]
 
-env:
-  # Customize the CMake build type here (Release, Debug, etc.)
-  BUILD_TYPE: Release
-
 jobs:
-  build:
-    uses: ./.github/workflows/build.yml
+  build-n-test:
+    uses: ./.github/workflows/build-n-test.yml
     with:
-      target: examples
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download Executables
-      uses: actions/download-artifact@v3
-      with:
-        name: build
-        path: ${{github.workspace}}/build
-    - name: Change Permission
-      shell: bash
-      # Downloaded artifacts loose permissions.
-      # See https://github.com/actions/download-artifact/blob/main/README.md
-      run: chmod +wx build/tests/* build/examples/*
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE -L E2E --output-on-failure
+      target: E2Etests

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "**" ]
 
 jobs:
-  E2Etests:
+  build:
     uses: ./.github/workflows/build-n-test.yml
     with:
       target: E2Etests

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "**" ]
 
 jobs:
-  build-n-test:
+  E2Etests:
     uses: ./.github/workflows/build-n-test.yml
     with:
       target: E2Etests

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "**" ]
 
 jobs:
-  unittests:
+  build:
     uses: ./.github/workflows/build-n-test.yml
     with:
       target: unittests

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,32 +6,8 @@ on:
   pull_request:
     branches: [ "**" ]
 
-env:
-  # Customize the CMake build type here (Release, Debug, etc.)
-  BUILD_TYPE: Release
-
 jobs:
-  build:
-    uses: ./.github/workflows/build.yml
+  build-n-test:
+    uses: ./.github/workflows/build-n-test.yml
     with:
       target: unittests
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download Executables
-      uses: actions/download-artifact@v3
-      with:
-        name: build
-        path: ${{github.workspace}}/build
-    - name: Change Permission
-      shell: bash
-      # Downloaded artifacts loose permissions.
-      # See https://github.com/actions/download-artifact/blob/main/README.md
-      run: chmod +wx build/tests/* build/examples/*
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE -L unit --output-on-failure

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "**" ]
 
 jobs:
-  build-n-test:
+  unittests:
     uses: ./.github/workflows/build-n-test.yml
     with:
       target: unittests

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <!-- This file is part of Bembel, the higher order C++ boundary element library.
-It was written as part of a cooperation of J. Dölz, H. Harbrecht, S. Kurz, 
-M. Multerer, S. Schöps, and F. Wolf at Technische Universitaet Darmstadt, 
-Universitaet Basel, and Universita della Svizzera italiana, Lugano. This 
-source code is subject to the GNU General Public License version 3 and 
-provided WITHOUT ANY WARRANTY, see <http://www.bembel.eu> for further 
+
+Copyright (C) 2022 see <http://www.bembel.eu>
+
+It was written as part of a cooperation of J. Doelz, H. Harbrecht, S. Kurz,
+M. Multerer, S. Schoeps, and F. Wolf at Technische Universitaet Darmstadt,
+Universitaet Basel, and Universita della Svizzera italiana, Lugano. This
+source code is subject to the GNU General Public License version 3 and
+provided WITHOUT ANY WARRANTY, see <http://www.bembel.eu> for further
 information. -->
 # Bembel
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -174,6 +177,7 @@ Contributors include (alphabetically):
 *   [J. Dölz](#JD), 
 *   [H. Harbrecht](#HeHa), 
 *   [M. Multerer](#MM), 
+*   [M. Nolte](#MN), 
 *   [F. Wolf](#FW).
 
 ## 10. About the People <a name="people"></a>
@@ -187,23 +191,26 @@ Contributors include (alphabetically):
 [Departement Mathematik und Informatik](https://dmi.unibas.ch/de/home/) 
 at the University of Basel.
 
-* [Stefan Kurz](https://www.temf.tu-darmstadt.de/temf/mitarbeiter/mitarbeiterdetails_57408.en.jsp)
-<a name="SK"></a> currently holds a professorship at the 
-[Institute TEMF](https://www.temf.tu-darmstadt.de/temf/index.en.jsp) 
-at TU Darmstadt and is Vice President for Hybrid Modelling at Robert Bosch GmbH.
+* [Stefan Kurz](https://gepris.dfg.de/gepris/person/1810768)
+<a name="SK"></a> currently holds a professorship at the University of Jyväskylä.
 
 * [Michael Multerer](https://www.ics.usi.ch/index.php/people-detail-page/297-prof-michael-multerer) 
 <a name="MM"></a> currently holds a professorship 
 at the Institute of Computational Science at the Università della Svizzera italiana in Lugano.
 He may also be found [on GitHub](https://github.com/muchip).
 
-* [Sebastian Schöps](https://www.cem.tu-darmstadt.de/cem/group/ref_group_details_27328.en.jsp
+* [Maximilian Nolte](https://www.cem.tu-darmstadt.de/cem/group/nolte.en.jsp) 
+<a name="MN"></a>is currently a PhD student at the 
+[Institute TEMF](https://www.temf.tu-darmstadt.de/temf/index.en.jsp) at TU Darmstadt. He may also be found 
+[on GitHub](https://github.com/mx-nlte).
+
+* [Sebastian Schöps](https://www.cem.tu-darmstadt.de/cem/group/schops.en.jsp
 )<a name="SSc"></a> currently holds a professorship at the 
 [Institute TEMF](https://www.temf.tu-darmstadt.de/temf/index.en.jsp) 
 at TU Darmstadt. He may also be found [on GitHub](https://github.com/schoeps).
 
-* [Felix Wolf](https://www.cem.tu-darmstadt.de/cem/group/ref_group_details_57665.en.jsp) 
-<a name="FW"></a>is currently a postdoc at the 
+* [Felix Wolf](https://www.cem.tu-darmstadt.de/cem/group/wolf.en.jsp) 
+<a name="FW"></a>is currently a lecturer at the 
 [Institute TEMF](https://www.temf.tu-darmstadt.de/temf/index.en.jsp) at TU Darmstadt. He may also be found 
 [on GitHub](https://github.com/flx-wlf).
 
@@ -213,6 +220,7 @@ at TU Darmstadt. He may also be found [on GitHub](https://github.com/schoeps).
 Work on Bembel was conducted with the following financial support (alphabetically):
 *  DFG Grant KU1553/4-1,
 *  DFG Grant SCHO1562/3-1,
+*  DFG Grant SCHO1562/7,
 *  The Graduate School of Computational Engineering at TU Darmstadt and the Excellence Initiative of the German Federal and State Governments and the Graduate School of Computational Engineering at TU Darmstadt,
 *  SNSF Grant 137669,
 *  SNSF Grant 156101,

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,8 +28,8 @@ endforeach()
 
 enable_testing()
 
-add_custom_target(examples)
-add_dependencies(examples ${CIFILES})
+add_custom_target(E2E)
+add_dependencies(E2E ${CIFILES})
 
 ###############################################################################
 # examples not being run from CI

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,13 +23,13 @@ foreach(file IN LISTS CIFILES)
   add_executable(${file} ${file})
   target_link_libraries(${file} Eigen3::Eigen)
   add_test(${file}Example ${file})
-  set_tests_properties(${file}Example PROPERTIES LABELS "E2E")
+  set_tests_properties(${file}Example PROPERTIES LABELS "E2Etests")
 endforeach()
 
 enable_testing()
 
-add_custom_target(E2E)
-add_dependencies(E2E ${CIFILES})
+add_custom_target(E2Etests)
+add_dependencies(E2Etests ${CIFILES})
 
 ###############################################################################
 # examples not being run from CI

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CIFILES
     )
 
 foreach(file IN LISTS CIFILES)
-  add_executable(${file} ${file})
+  add_executable(${file} ${file}.cpp)
   target_link_libraries(${file} Eigen3::Eigen)
   add_test(${file}Example ${file})
   set_tests_properties(${file}Example PROPERTIES LABELS "E2Etests")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,6 +43,6 @@ set(NOCIFILES
     )
 
   foreach(file IN LISTS NOCIFILES)
-  add_executable(${file}.out ${file})
-  target_link_libraries(${file}.out Eigen3::Eigen)
+  add_executable(${file} ${file}.cpp)
+  target_link_libraries(${file} Eigen3::Eigen)
 endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,10 +13,10 @@ foreach(file IN LISTS UNITTESTS)
   add_executable(${file} ${file}.cpp)
   target_link_libraries(${file} Eigen3::Eigen)
   add_test(${file}Unittest ${file})
-  set_tests_properties(${file}Unittest PROPERTIES LABELS "unittest")
+  set_tests_properties(${file}Unittest PROPERTIES LABELS "unittests")
 endforeach()
 
 enable_testing()
 
-add_custom_target(unittest)
-add_dependencies(unittest ${UNITTESTS})
+add_custom_target(unittests)
+add_dependencies(unittests ${UNITTESTS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,10 +13,10 @@ foreach(file IN LISTS UNITTESTS)
   add_executable(${file} ${file}.cpp)
   target_link_libraries(${file} Eigen3::Eigen)
   add_test(${file}Unittest ${file})
-  set_tests_properties(${file}Unittest PROPERTIES LABELS "unit")
+  set_tests_properties(${file}Unittest PROPERTIES LABELS "unittest")
 endforeach()
 
 enable_testing()
 
-add_custom_target(unittests)
-add_dependencies(unittests ${UNITTESTS})
+add_custom_target(unittest)
+add_dependencies(unittest ${UNITTESTS})


### PR DESCRIPTION
This simplifies the callable GitHub actions workflow to not use artifacts and fixes a CMake warning due to non-specific source files. The readme is updated to add M.Nolte, update some links and job titles.