### PR TITLE
Adds Github Action Test Coverage Monitor on Pullrequests

### DIFF
--- a/.github/workflows/monitor-coverage.yml
+++ b/.github/workflows/monitor-coverage.yml
@@ -1,0 +1,48 @@
+name: Coverage Monitor
+
+on:
+  pull_request:
+    branches: [ "**" ]
+
+env:
+  BUILD_TYPE: Coverage
+
+jobs:
+  coverage-monitor:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Configure system
+      run: sudo apt-get update
+    
+    - name: Install Eigen3
+      run: sudo apt-get install --yes libeigen3-dev
+
+    - name: Install Gcovr
+      run: sudo apt install gcovr
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -B build
+
+    - name: Build
+      shell: bash
+      run: cmake --build build --config $BUILD_TYPE -j 2
+
+    - name: Run Unittests
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: ctest -C $BUILD_TYPE -L unittests --output-on-failure
+
+    - name: Create Coverage Report
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: gcovr -f ../Bembel -r ../ 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,46 +71,36 @@ find_package (Eigen3 3.3 REQUIRED NO_MODULE)
 
 set (BEMBEL_PATH "${PROJECT_SOURCE_DIR}")
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-march=native" MARCHNATIVE)
-CHECK_CXX_COMPILER_FLAG("-flto" FLTO)
-
 set(CMAKE_CXX_STANDARD 11)
 include_directories(${BEMBEL_PATH})
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING
+      "Choose the type of build, options are: Debug Release."
+      FORCE)
+endif()
+
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-march=native" MARCHNATIVE)
 if (MARCHNATIVE)
-message(STATUS "Found -march=native, adding option to builds of type >release< only")
+message(STATUS "Found -march=native, adding option to builds of type >Release< only")
 set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native" CACHE STRING "compile flags" FORCE)
 endif()
+
+CHECK_CXX_COMPILER_FLAG("-flto" FLTO)
 if (FLTO)
-message(STATUS "Found -flto, adding option to builds of type >release< only")
+message(STATUS "Found -flto, adding option to builds of type >Release< only")
 set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto" CACHE STRING "compile flags" FORCE)
 endif()
 
 find_package(OpenMP)
 if (OPENMP_FOUND)
-message(STATUS "Found -fopenmp, adding option to builds of type >release< only")
+message(STATUS "Found -fopenmp, adding option to builds of type >Release< only")
 set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fopenmp")
 endif()
-
-set( PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}")
-include_directories("${PROJECT_SOURCE_DIR}")
-
-
-add_custom_target(debug
-  COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug ${CMAKE_SOURCE_DIR}
-  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target all
-  COMMENT "Switch CMAKE_BUILD_TYPE to Debug"
-  )
-
-add_custom_target(release
-  COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Release ${CMAKE_SOURCE_DIR}
-  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target all
-  COMMENT "Switch CMAKE_BUILD_TYPE to Release"
-  )
-
 
 add_subdirectory(tests)
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ message(STATUS "Found -fopenmp, adding option to builds of type >Release< only")
 set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fopenmp")
 endif()
 
+set(CMAKE_CXX_FLAGS_COVERAGE "-g --coverage -fprofile-abs-path" CACHE STRING
+    "Flags used by the coverage test."
+    FORCE)
+
 add_subdirectory(tests)
 add_subdirectory(examples)
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-march=native" MARCHNATIVE)
 CHECK_CXX_COMPILER_FLAG("-flto" FLTO)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -I${BEMBEL_PATH}")
+set(CMAKE_CXX_STANDARD 11)
+include_directories(${BEMBEL_PATH})
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 


### PR DESCRIPTION
This change adds a GitHub action workflow to monitor the test coverage by the unittests. Currently the percentage is only visible in the action output.