### PR TITLE
Fix MSVC compilation issues on Windows (M_PI, typeof)

### DIFF
--- a/Bembel/src/util/Constants.hpp
+++ b/Bembel/src/util/Constants.hpp
@@ -1,4 +1,4 @@
-// This file is part of Bembel, the higher order C++ boundary element library.
+﻿// This file is part of Bembel, the higher order C++ boundary element library.
 //
 // Copyright (C) 2022 see <http://www.bembel.eu>
 //
@@ -11,6 +11,10 @@
 #ifndef BEMBEL_SRC_UTIL_CONSTANTS_HPP_
 #define BEMBEL_SRC_UTIL_CONSTANTS_HPP_
 
+#ifndef M_PI
+// since M_PI is not defined in Windows MSVC++ 
+#define M_PI 3.14159265358979323846
+#endif
 namespace Bembel {
 namespace Constants {
 

--- a/examples/HelmholtzAdjointDoubleLayerH2.cpp
+++ b/examples/HelmholtzAdjointDoubleLayerH2.cpp
@@ -1,4 +1,4 @@
-// This file is part of Bembel, the higher order C++ boundary element library.
+﻿// This file is part of Bembel, the higher order C++ boundary element library.
 //
 // Copyright (C) 2024 see <http://www.bembel.eu>
 //
@@ -94,7 +94,7 @@ int main() {
       auto system_matrix = -0.5 * M + AK;  // important: do NOT change auto!
 
       // solve system
-      GMRES<typeof(system_matrix), IdentityPreconditioner> gmres;
+      GMRES<decltype(system_matrix), IdentityPreconditioner> gmres;
       gmres.compute(system_matrix);
       VectorXcd rho = gmres.solve(disc_lf.get_discrete_linear_form());
 

--- a/examples/HelmholtzDoubleLayerH2.cpp
+++ b/examples/HelmholtzDoubleLayerH2.cpp
@@ -1,4 +1,4 @@
-// This file is part of Bembel, the higher order C++ boundary element library.
+﻿// This file is part of Bembel, the higher order C++ boundary element library.
 //
 // Copyright (C) 2024 see <http://www.bembel.eu>
 //
@@ -90,7 +90,7 @@ int main() {
       auto system_matrix = 0.5 * M + K;  // important: do NOT change auto!
 
       // solve system
-      GMRES<typeof(system_matrix), IdentityPreconditioner> gmres;
+      GMRES<decltype(system_matrix), IdentityPreconditioner> gmres;
       gmres.compute(system_matrix);
       VectorXcd rho = gmres.solve(disc_lf.get_discrete_linear_form());
 

--- a/examples/LaplaceAdjointDoubleLayerH2.cpp
+++ b/examples/LaplaceAdjointDoubleLayerH2.cpp
@@ -1,4 +1,4 @@
-// This file is part of Bembel, the higher order C++ boundary element library.
+﻿// This file is part of Bembel, the higher order C++ boundary element library.
 //
 // Copyright (C) 2024 see <http://www.bembel.eu>
 //
@@ -90,7 +90,7 @@ int main() {
       auto system_matrix = 0.5 * M + AK;  // important: do NOT change auto!
 
       // solve system
-      GMRES<typeof(system_matrix), IdentityPreconditioner> gmres;
+      GMRES<decltype(system_matrix), IdentityPreconditioner> gmres;
       gmres.compute(system_matrix);
       VectorXd rho = gmres.solve(disc_lf.get_discrete_linear_form());
 

--- a/examples/LaplaceDoubleLayerH2.cpp
+++ b/examples/LaplaceDoubleLayerH2.cpp
@@ -1,4 +1,4 @@
-// This file is part of Bembel, the higher order C++ boundary element library.
+﻿// This file is part of Bembel, the higher order C++ boundary element library.
 //
 // Copyright (C) 2024 see <http://www.bembel.eu>
 //
@@ -87,7 +87,7 @@ int main() {
       auto system_matrix = -0.5 * M + K;  // important: do NOT change auto!
 
       // solve system
-      GMRES<typeof(system_matrix), IdentityPreconditioner> gmres;
+      GMRES<decltype(system_matrix), IdentityPreconditioner> gmres;
       gmres.compute(system_matrix);
       VectorXd rho = gmres.solve(disc_lf.get_discrete_linear_form());
 


### PR DESCRIPTION
This pull request addresses two compilation errors encountered when building the project on Windows using the MSVC compiler.

1.  **`M_PI` Undeclared Identifier**
    *   **Error:**
        ```
        D:\code\bembel\Bembel\src\util\Constants.hpp(42): error C2065: “M_PI”: undeclared identifier
        D:\code\bembel\Bembel\src\util\Constants.hpp(42): error C2737: “Bembel::Constants::mu0”: must initialize constexpr object
        ```
    *   **Problem:** On some platforms and compilers (including MSVC by default), `M_PI` is not automatically defined in `<cmath>` or `<math.h>`. It often requires a specific macro like `_USE_MATH_DEFINES` to be set before including these headers.
    *   **Solution:** Added an `#ifndef M_PI` guard with a standard definition of PI in `src/util/Constants.hpp`. This ensures `M_PI` is available even if the compiler settings don't provide it.
        ```cpp
        #ifndef M_PI
        #define M_PI 3.14159265358979323846
        #endif

        // Original code that uses M_PI
        constexpr double mu0 = 4 * M_PI * 1e-7;
        ```

2.  **`typeof` Identifier Not Found**
    *   **Error:**
        ```
        D:\code\bembel\examples\LaplaceAdjointDoubleLayerH2.cpp(93): error C3861: “typeof”: identifier not found
        D:\code\bembel\examples\LaplaceAdjointDoubleLayerH2.cpp(93): error C2923: "Eigen::GMRES": "typeof" is not a valid template type argument for parameter "_MatrixType"
        ```
    *   **Problem:** `typeof` is a non-standard language extension, typically supported by GCC and Clang. It is not a standard C++ keyword and is not recognized by MSVC.
    *   **Solution:** Replaced the non-standard `typeof` with the standard C++11 keyword `decltype` in `examples/LaplaceAdjointDoubleLayerH2.cpp`. `decltype(expr)` is the standard way to obtain the type of an expression.
        ```cpp
        // Before: non-standard typeof
        GMRES<typeof(system_matrix), IdentityPreconditioner> gmres;

        // After: standard C++11 decltype
        GMRES<decltype(system_matrix), IdentityPreconditioner> gmres;
        ```

**Verification:**

These changes have been tested and successfully resolve the compilation errors on Windows using Visual Studio 2022 (MSVC).